### PR TITLE
Remove write access to town hall

### DIFF
--- a/components/dot_menu/dot_menu.jsx
+++ b/components/dot_menu/dot_menu.jsx
@@ -24,6 +24,7 @@ export default class DotMenu extends Component {
         isFlagged: PropTypes.bool,
         handleCommentClick: PropTypes.func,
         handleDropdownOpened: PropTypes.func,
+        isReadOnly: PropTypes.bool,
 
         actions: PropTypes.shape({
 
@@ -58,7 +59,8 @@ export default class DotMenu extends Component {
         idCount: -1,
         post: {},
         commentCount: 0,
-        isFlagged: false
+        isFlagged: false,
+        isReadOnly: false
     }
 
     constructor(props) {
@@ -144,7 +146,7 @@ export default class DotMenu extends Component {
         let dotMenuPermalink = null;
         let dotMenuPin = null;
         if (!isSystemMessage) {
-            if (this.props.idPrefix === Constants.CENTER) {
+            if (!this.props.isReadOnly && this.props.idPrefix === Constants.CENTER) {
                 dotMenuReply = (
                     <DotMenuItem
                         idPrefix={idPrefix + 'Reply'}
@@ -161,18 +163,19 @@ export default class DotMenu extends Component {
                     post={this.props.post}
                 />
             );
-
-            dotMenuPin = (
-                <DotMenuItem
-                    idPrefix={idPrefix + 'Pin'}
-                    idCount={this.props.idCount}
-                    post={this.props.post}
-                    actions={{
-                        pinPost: this.props.actions.pinPost,
-                        unpinPost: this.props.actions.unpinPost
-                    }}
-                />
-            );
+            if (!this.props.isReadOnly) {
+                dotMenuPin = (
+                    <DotMenuItem
+                        idPrefix={idPrefix + 'Pin'}
+                        idCount={this.props.idCount}
+                        post={this.props.post}
+                        actions={{
+                            pinPost: this.props.actions.pinPost,
+                            unpinPost: this.props.actions.unpinPost
+                        }}
+                    />
+                );
+            }
         }
 
         let dotMenuDelete = null;

--- a/components/post_view/post/post.jsx
+++ b/components/post_view/post/post.jsx
@@ -93,7 +93,16 @@ export default class Post extends React.PureComponent {
         /**
          * Function to get the post list HTML element
          */
-        getPostList: PropTypes.func.isRequired
+        getPostList: PropTypes.func.isRequired,
+
+        /**
+         * Set not to allow edits on post
+         */
+        isReadOnly: PropTypes.bool
+    }
+
+    static defaultProps = {
+        isReadOnly: false
     }
 
     constructor(props) {
@@ -309,6 +318,7 @@ export default class Post extends React.PureComponent {
                                 showTimeWithoutHover={!hideProfilePicture}
                                 getPostList={this.props.getPostList}
                                 hover={this.state.hover}
+                                isReadOnly={this.props.isReadOnly}
                             />
                             <PostBody
                                 post={post}

--- a/components/post_view/post_header/post_header.jsx
+++ b/components/post_view/post_header/post_header.jsx
@@ -82,7 +82,16 @@ export default class PostHeader extends React.PureComponent {
         /*
          * Set to render the post time when not hovering
          */
-        showTimeWithoutHover: PropTypes.bool
+        showTimeWithoutHover: PropTypes.bool,
+
+        /**
+         * Set not to allow edits on post
+         */
+        isReadOnly: PropTypes.bool
+    }
+
+    static defaultProps = {
+        isReadOnly: false
     }
 
     constructor(props) {
@@ -162,6 +171,7 @@ export default class PostHeader extends React.PureComponent {
                         showTimeWithoutHover={this.props.showTimeWithoutHover}
                         getPostList={this.props.getPostList}
                         hover={this.props.hover}
+                        isReadOnly={this.props.isReadOnly}
                     />
                 </div>
             </div>

--- a/components/post_view/post_info/post_info.jsx
+++ b/components/post_view/post_info/post_info.jsx
@@ -89,6 +89,11 @@ export default class PostInfo extends React.PureComponent {
          */
         showTimeWithoutHover: PropTypes.bool.isRequired,
 
+        /**
+         * Set not to allow edits on post
+         */
+        isReadOnly: PropTypes.bool,
+
         actions: PropTypes.shape({
 
             /*
@@ -102,6 +107,10 @@ export default class PostInfo extends React.PureComponent {
             addReaction: PropTypes.func.isRequired
         }).isRequired
     };
+
+    static defaultProps = {
+        isReadOnly: false
+    }
 
     constructor(props) {
         super(props);
@@ -166,13 +175,13 @@ export default class PostInfo extends React.PureComponent {
             return null;
         }
 
-        const isMobile = this.props.isMobile;
+        const {isMobile, isReadOnly} = this.props;
         const hover = this.props.hover || this.state.showEmojiPicker || this.state.showDotMenu;
 
         let comments;
         let react;
 
-        if (!isSystemMessage) {
+        if (!isReadOnly && !isSystemMessage) {
             if (isMobile || hover || (!post.root_id && this.props.replyCount) || this.props.isFirstReply) {
                 const extraClass = isMobile ? '' : 'pull-right';
                 comments = (
@@ -221,6 +230,7 @@ export default class PostInfo extends React.PureComponent {
                     isFlagged={this.props.isFlagged}
                     handleCommentClick={this.props.handleCommentClick}
                     handleDropdownOpened={this.handleDotMenuOpened}
+                    isReadOnly={isReadOnly}
                 />
             );
         }
@@ -228,7 +238,7 @@ export default class PostInfo extends React.PureComponent {
         return (
             <div
                 ref='dotMenu'
-                className='col col__reply'
+                className={'col col__reply' + (isReadOnly ? ' dot_small' : '')}
             >
                 {dotMenu}
                 {react}

--- a/components/post_view/post_list.jsx
+++ b/components/post_view/post_list.jsx
@@ -68,7 +68,7 @@ export default class PostList extends React.PureComponent {
         fullWidth: PropTypes.bool,
 
         /**
-         * Set not to allow edits on channel
+         * Set not to allow edits on post list
          */
         isReadOnly: PropTypes.bool.isRequired,
 
@@ -445,6 +445,7 @@ export default class PostList extends React.PureComponent {
                     post={post}
                     lastPostCount={(i >= 0 && i < Constants.TEST_ID_COUNT) ? i : -1}
                     getPostList={this.getPostList}
+                    isReadOnly={this.props.isReadOnly}
                 />
             );
 

--- a/components/sidebar.jsx
+++ b/components/sidebar.jsx
@@ -548,11 +548,12 @@ export default class Sidebar extends React.Component {
             unread = msgCount > 0 || channelMember.mention_count > 0;
         }
 
-        if (!unread && channel.id !== activeId &&
-            channel.name === Constants.DEFAULT_CHANNEL &&
-            this.state.isTownSquareReadOnly
+        if (channel.name === Constants.DEFAULT_CHANNEL &&
+            this.state.isTownSquareReadOnly &&
+            !unread && channel.id !== activeId &&
+            !ChannelUtils.isFavoriteChannel(channel)
         ) {
-            return;
+            return '';
         }
 
         if (unread) {

--- a/sass/layout/_post.scss
+++ b/sass/layout/_post.scss
@@ -1263,6 +1263,10 @@
             top: -4px;
             white-space: normal;
             z-index: 6;
+
+            &.dot_small {
+                min-width: auto !important;
+            }
         }
 
         .col__remove {

--- a/tests/components/post_view/post_info/__snapshots__/post_info.test.jsx.snap
+++ b/tests/components/post_view/post_info/__snapshots__/post_info.test.jsx.snap
@@ -182,6 +182,7 @@ exports[`components/post_view/PostInfo should match snapshot, hover 1`] = `
       idCount={-1}
       idPrefix="center"
       isFlagged={false}
+      isReadOnly={false}
       post={
         Object {
           "channel_id": "g6139tbospd18cmxroesdk3kkc",


### PR DESCRIPTION
Remove the "reply", "pin" and "emoji" options from the menu, that would gate all actions behind system admin rights. Allow Permalinks in the post menu. Admin could do like an upvote/downvote reaction to their own post and then users could take that action, too.
Do not hide `Town square` when it's favorited.
