### PR TITLE
Parse SupportedTimezones from mm_config

### DIFF
--- a/components/suggestion/timezone_provider.jsx
+++ b/components/suggestion/timezone_provider.jsx
@@ -5,12 +5,12 @@ import React from 'react';
 
 import AppDispatcher from 'dispatcher/app_dispatcher.jsx';
 import {ActionTypes} from 'utils/constants.jsx';
-import {getTimezoneRegion} from 'utils/timezone';
+import {getSupportedTimezones, getTimezoneRegion} from 'utils/timezone';
 
 import Provider from './provider.jsx';
 import Suggestion from './suggestion.jsx';
 
-const timezones = global.mm_config ? global.mm_config.SupportedTimezones : [];
+const timezones = getSupportedTimezones();
 
 class TimezoneSuggestion extends Suggestion {
     render() {

--- a/utils/timezone.jsx
+++ b/utils/timezone.jsx
@@ -6,6 +6,13 @@ import * as UserActions from 'actions/user_actions.jsx';
 
 const dateTimeFormat = new Intl.DateTimeFormat();
 
+export function getSupportedTimezones() {
+    if (global.mm_config && global.mm_config.SupportedTimezones) {
+        return global.mm_config.SupportedTimezones.split(',');
+    }
+    return [];
+}
+
 export function getBrowserTimezone() {
     return dateTimeFormat.resolvedOptions().timeZone;
 }


### PR DESCRIPTION
This change is needed after serializing `SupportedTimezones` to a string