### PR TITLE
UCHAT-3015 Line Spacing with Emoji is wrong

### DIFF
--- a/sass/components/_emoticons.scss
+++ b/sass/components/_emoticons.scss
@@ -15,13 +15,11 @@
     background-repeat: no-repeat;
     background-size: contain;
     display: inline-block;
-    height: 1.8em;
+    height: 21px;
     min-height: 1em;
     min-width: 1em;
     vertical-align: middle;
-    width: 1.8px;
-    margin-bottom: .25em;
-    width: 1.8em;
+    width: 21px;
     object-fit: contain;
 }
 

--- a/sass/responsive/_mobile_uchat.scss
+++ b/sass/responsive/_mobile_uchat.scss
@@ -1,6 +1,12 @@
 @charset 'UTF-8';
 
 @media screen and (max-width: 768px) {
+    .textarea-wrapper {
+        .help__text {
+            display: none;
+        }
+    }
+
     .webrtc__option {
         display: none;
     }
@@ -44,6 +50,8 @@
     }
 
     .post-create__container {
+        z-index: 2;
+
         .post-create-footer {
             padding: 0 10px;
         }
@@ -382,6 +390,7 @@
             padding-right: 70px;
 
             .col__reply {
+                min-width: 45px;
                 top: -3px;
                 width: 65px;
                 z-index: auto;
@@ -1010,8 +1019,10 @@
                     opacity: 1;
                     padding-top: 13px;
                     position: fixed;
+                    right: 20px;
                     text-align: center;
                     text-shadow: none;
+                    top: 20px;
                     width: 30px;
                 }
 
@@ -1064,6 +1075,7 @@
 
     .footer-pane {
         .footer-link {
+            display: block;
             line-height: 1.7;
             padding: 0;
             text-align: right;
@@ -1089,8 +1101,10 @@
         .search__form {
             @include single-transition(all, .2s, linear);
             @include translateX(0);
+            background: $white;
             border: none;
             margin-top: 9px;
+            padding-left: 40px;
             width: 100%;
 
             .fa-spin {
@@ -1240,8 +1254,10 @@
                         .btn-close {
                             @include opacity(.5);
                             display: block;
+                            font-size: 25px;
                             right: 4px;
                             text-align: center;
+                            top: 4px;
                             width: 40px;
                         }
                     }
@@ -1480,7 +1496,7 @@
 }
 
 @media screen and (max-width: 640px) {
-    .col__reply {
+    .post__header {
         .dropdown-menu {
             > li {
                 > button {
@@ -1939,6 +1955,15 @@
 }
 
 @media screen and (max-width: 320px) {
+    .post {
+        &.post--system {
+             .post__header {
+                padding: 0;
+             }
+        }
+
+    }
+
     .multi-teams {
         .sidebar--left {
             width: 220px;


### PR DESCRIPTION
#### Summary
UCHAT-3015 Line Spacing with Emoji is wrong. This was a custom uChat emoji size and spacing. Reverted to MM's one.

#### Ticket Link
https://jira.uberinternal.com/browse/UCHAT-3015

<img width="1430" alt="screen shot 2018-04-23 at 1 40 21 pm" src="https://user-images.githubusercontent.com/160621/39147547-8ae9dc92-46ff-11e8-86b5-0f935e9682d6.png">
<img width="1430" alt="emoji-sizes-after" src="https://user-images.githubusercontent.com/160621/39147564-9894edc8-46ff-11e8-952e-13eddc41baa9.png">
<img width="1430" alt="emoji-sizes-before" src="https://user-images.githubusercontent.com/160621/39147565-98adaa3e-46ff-11e8-8705-bb8a0fa12de7.png">


