### PR TITLE
UCHAT-2873 Job title text invisible in uChat Dark theme

### DIFF
--- a/sass/components/_popover.scss
+++ b/sass/components/_popover.scss
@@ -75,7 +75,6 @@
 
     &#user-profile-popover-new {
         text-align: center;
-        background: transparent;
         border: none;
         box-shadow: none;
         .popover-title, .arrow {
@@ -87,13 +86,9 @@
             height: auto;
             overflow: auto;
             .profile-popover-container {
-                background-color: #ffffff;
                 overflow: auto;
                 width: 200px;
                 padding-top: 15px;
-                -webkit-box-shadow: 0 0 10px 0 rgba(0,0,0,0.5);
-                -moz-box-shadow: 0 0 10px 0 rgba(0,0,0,0.5);
-                box-shadow: 0 0 10px 0 rgba(0,0,0,0.5);
                 .user-popover__image {
                     height: 100px;
                     width: 100px;
@@ -103,6 +98,7 @@
                     -o-border-radius: 100px;
                     border-radius: 100px;
                     margin: 0;
+                    border: 1px solid gray;
                 }
                 .profile-popover-name {
                     padding: 0 12px;

--- a/utils/utils.jsx
+++ b/utils/utils.jsx
@@ -681,6 +681,10 @@ export function applyTheme(theme) {
     }
 
     if (theme.centerChannelColor) {
+        changeCss('.app__body .popover#user-profile-popover-new .popover-content .profile-popover-container', 'box-shadow: 0 0 10px 0' + changeOpacity(theme.centerChannelColor, 0.5));
+        changeCss('.app__body .popover#user-profile-popover-new .popover-content .profile-popover-container', '-webkit-box-shadow: 0 0 10px 0 ' + changeOpacity(theme.centerChannelColor, 0.5));
+        changeCss('.app__body .popover#user-profile-popover-new .popover-content .profile-popover-container', '-moz-box-shadow: 0 0 10px 0 ' + changeOpacity(theme.centerChannelColor, 0.5));
+
         changeCss('.app__body .mentions__name .status.status--group, .app__body .multi-select__note', 'background:' + changeOpacity(theme.centerChannelColor, 0.12));
         changeCss('.app__body .file-view--single .file__image .image-loaded, .app__body .post .dropdown .dropdown-menu button, .app__body .member-list__popover .more-modal__body, .app__body .alert.alert-transparent, .app__body .channel-header .channel-header__icon, .app__body .search-bar__container .search__form, .app__body .table > thead > tr > th, .app__body .table > tbody > tr > td', 'border-color:' + changeOpacity(theme.centerChannelColor, 0.12));
         changeCss('.app__body .post-list__arrows, .app__body .post .flag-icon__container', 'fill:' + changeOpacity(theme.centerChannelColor, 0.3));


### PR DESCRIPTION
#### Summary
Apply Dark theme styles to the profile popover.
Also, include a gray border around the image so it can stand out

#### Ticket Link
https://jira.uberinternal.com/browse/UCHAT-2873

<img width="359" alt="screen shot 2018-04-23 at 6 25 50 pm" src="https://user-images.githubusercontent.com/6182543/39156365-cc964878-4723-11e8-8535-75849072bb41.png">
<img width="441" alt="screen shot 2018-04-23 at 6 25 18 pm" src="https://user-images.githubusercontent.com/6182543/39156366-ccaae1a2-4723-11e8-89d7-97bf8e64f0c2.png">




