### PR TITLE
UCHAT-2874 uChat font colors are wrong

### DIFF
--- a/sass/responsive/_mobile_uchat.scss
+++ b/sass/responsive/_mobile_uchat.scss
@@ -118,7 +118,7 @@
         }
 
         a {
-            color: #0091ff;
+            color: #11939a;
         }
 
         .arrow {


### PR DESCRIPTION
#### Summary
Just had to change the color of the a tags in the header-popover component.
Ensured if the MM color was used elsewhere.
```
a {
    color: #0091ff;
}
```
Just used in `_mobile.scss`, which is overriden by `_mobile_uchat.scss`

#### Ticket Link
https://jira.uberinternal.com/browse/UCHAT-2874

#### Before
<img width="399" alt="screen shot 2018-04-24 at 11 36 20 am" src="https://user-images.githubusercontent.com/6182543/39198063-1c081fa4-47b4-11e8-8e1d-ee01a79c5af8.png">

#### After
<img width="400" alt="screen shot 2018-04-24 at 11 35 35 am" src="https://user-images.githubusercontent.com/6182543/39198064-1c175f32-47b4-11e8-8cb9-c8b5d474e612.png">

