### PR TITLE
UCHAT-3031 Highlighted Search Terms are Hard to Read

### DIFF
--- a/utils/utils.jsx
+++ b/utils/utils.jsx
@@ -807,6 +807,12 @@ export function applyTheme(theme) {
         changeCss('.sidebar--right--expanded .sidebar--right__expand', 'color:' + theme.linkColor);
     }
 
+    if (theme.mentionHighlightBg === theme.linkColor) {
+        changeCss('.app__body .search-highlight .mention-link', 'color:' + theme.mentionHighlightLink);
+    } else {
+        changeCss('.app__body .search-highlight .mention-link', 'color:' + theme.linkColor);
+    }
+
     if (theme.buttonBg) {
         changeCss('.app__body .post-image__details .post-image__download svg:hover, .app__body .file-view--single .file__download:hover, .app__body .new-messages__button div, .app__body .btn.btn-primary, .app__body .tutorial__circles .circle.active, .app__body .post__pinned-badge', 'background:' + theme.buttonBg);
         changeCss('.app__body .post-image__details .post-image__download svg:hover', 'border-color:' + theme.buttonBg);


### PR DESCRIPTION
#### Summary
The uChat dark theme has these properties
```
   linkColor: '#11939a',
   mentionHighlightBg: '#11939a',
```

There's a clash between `linkColor` and `mentionHighlightBg`.  That's why you see that cyan on cyan bug.

The easiest way would be to change the theme but that would break the entire app.  More work to ensure the app does not look broken.

Since we know this only occurs when searching. I applied a style change only to the search terms that are links.

One thing to note,  if a user reverts to a light theme the check (in utils/utils.js) fails to revert to the proper theme.  

I have an `else` check that reverts it properly so we do not introduce any regression


#### Ticket Link
https://jira.uberinternal.com/browse/UCHAT-3031

### Before
<img width="413" alt="screen shot 2018-04-25 at 4 04 36 pm" src="https://user-images.githubusercontent.com/6182543/39271046-dc4e615a-48a5-11e8-993f-dc9a52dd2dfa.png">
<img width="420" alt="screen shot 2018-04-25 at 4 04 26 pm" src="https://user-images.githubusercontent.com/6182543/39271047-dc68928c-48a5-11e8-991a-36ea414d7aad.png">


### After
<img width="414" alt="screen shot 2018-04-25 at 4 05 25 pm" src="https://user-images.githubusercontent.com/6182543/39271059-e3b2b842-48a5-11e8-800e-7244a4cee1c9.png">
<img width="412" alt="screen shot 2018-04-25 at 4 05 14 pm" src="https://user-images.githubusercontent.com/6182543/39271060-e3cbb392-48a5-11e8-97d8-46dae5c0b0eb.png">


