### PR TITLE
UCHAT-3130 Dropdown menu has close icon at the top instead of bottom

### DIFF
--- a/sass/responsive/_mobile_uchat.scss
+++ b/sass/responsive/_mobile_uchat.scss
@@ -1019,10 +1019,8 @@
                     opacity: 1;
                     padding-top: 13px;
                     position: fixed;
-                    right: 20px;
                     text-align: center;
                     text-shadow: none;
-                    top: 20px;
                     width: 30px;
                 }
 


### PR DESCRIPTION
#### Summary
Just a minor style regression with the close icon in the dropdown menu

#### Ticket Link
https://jira.uberinternal.com/browse/UCHAT-3130

#### Before
<img width="401" alt="screen shot 2018-04-26 at 5 06 29 pm" src="https://user-images.githubusercontent.com/6182543/39332231-de79cc7e-4974-11e8-8d07-0cd91aefff00.png">

#### After

<img width="401" alt="screen shot 2018-04-26 at 5 05 56 pm" src="https://user-images.githubusercontent.com/6182543/39332232-deac31b4-4974-11e8-8167-7649a7549234.png">
