### PR TITLE
UCHAT-2676 Added text for maximum file size

### DIFF
--- a/components/setting_picture.jsx
+++ b/components/setting_picture.jsx
@@ -256,7 +256,7 @@ export default class SettingPicture extends Component {
             helpText = (
                 <FormattedMessage
                     id={'setting_picture.help.profile'}
-                    defaultMessage='Upload a picture in BMP, JPG or PNG format.'
+                    defaultMessage='Upload a picture in BMP, JPG or PNG format. Maximum file size 15 MB.'
                 />
             );
         }

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -2773,7 +2773,7 @@
   "setting_item_max.save": "Save",
   "setting_item_min.edit": "Edit",
   "setting_picture.cancel": "Cancel",
-  "setting_picture.help.profile": "Upload a picture in BMP, JPG or PNG format.",
+  "setting_picture.help.profile": "Upload a picture in BMP, JPG or PNG format. Maximum file size 15 MB.",
   "setting_picture.help.team": "Upload a team icon in BMP, JPG or PNG format.<br>Square images with a solid background color are recommended.",
   "setting_picture.remove": "Remove this icon",
   "setting_picture.save": "Save",

--- a/i18n/ko.json
+++ b/i18n/ko.json
@@ -2773,7 +2773,7 @@
   "setting_item_max.save": "저장",
   "setting_item_min.edit": "편집",
   "setting_picture.cancel": "취소",
-  "setting_picture.help.profile": "Upload a picture in BMP, JPG or PNG format.",
+  "setting_picture.help.profile": "Upload a picture in BMP, JPG or PNG format. Maximum file size 15 MB.",
   "setting_picture.help.team": "Upload a team icon in BMP, JPG or PNG format.<br>Square images with a solid background color are recommended.",
   "setting_picture.remove": "Remove this icon",
   "setting_picture.save": "저장",

--- a/i18n/nl.json
+++ b/i18n/nl.json
@@ -2773,7 +2773,7 @@
   "setting_item_max.save": "Opslaan",
   "setting_item_min.edit": "Bewerken",
   "setting_picture.cancel": "Annuleren",
-  "setting_picture.help.profile": "Upload a picture in BMP, JPG or PNG format.",
+  "setting_picture.help.profile": "Upload a picture in BMP, JPG or PNG format. Maximum file size 15 MB.",
   "setting_picture.help.team": "Upload a team icon in BMP, JPG or PNG format.<br>Square images with a solid background color are recommended.",
   "setting_picture.remove": "Remove this icon",
   "setting_picture.save": "Opslaan",

--- a/i18n/pl.json
+++ b/i18n/pl.json
@@ -2773,7 +2773,7 @@
   "setting_item_max.save": "Zapisz",
   "setting_item_min.edit": "Edycja",
   "setting_picture.cancel": "Anuluj",
-  "setting_picture.help.profile": "Upload a picture in BMP, JPG or PNG format.",
+  "setting_picture.help.profile": "Upload a picture in BMP, JPG or PNG format. Maximum file size 15 MB.",
   "setting_picture.help.team": "Upload a team icon in BMP, JPG or PNG format.<br>Square images with a solid background color are recommended.",
   "setting_picture.remove": "Remove this icon",
   "setting_picture.save": "Zapisz",

--- a/i18n/ru.json
+++ b/i18n/ru.json
@@ -2773,7 +2773,7 @@
   "setting_item_max.save": "Сохранить",
   "setting_item_min.edit": "Изменить",
   "setting_picture.cancel": "Отмена",
-  "setting_picture.help.profile": "Upload a picture in BMP, JPG or PNG format.",
+  "setting_picture.help.profile": "Upload a picture in BMP, JPG or PNG format. Maximum file size 15 MB.",
   "setting_picture.help.team": "Upload a team icon in BMP, JPG or PNG format.<br>Square images with a solid background color are recommended.",
   "setting_picture.remove": "Remove this icon",
   "setting_picture.save": "Сохранить",

--- a/tests/components/__snapshots__/setting_picture.test.jsx.snap
+++ b/tests/components/__snapshots__/setting_picture.test.jsx.snap
@@ -30,7 +30,7 @@ exports[`components/SettingItemMin should match snapshot with active Save button
         className="setting-list-item padding-top x2"
       >
         <FormattedMessage
-          defaultMessage="Upload a picture in BMP, JPG or PNG format."
+          defaultMessage="Upload a picture in BMP, JPG or PNG format. Maximum file size 15 MB."
           id="setting_picture.help.profile"
           values={Object {}}
         />
@@ -111,7 +111,7 @@ exports[`components/SettingItemMin should match snapshot with active Save button
         className="setting-list-item padding-top x2"
       >
         <FormattedMessage
-          defaultMessage="Upload a picture in BMP, JPG or PNG format."
+          defaultMessage="Upload a picture in BMP, JPG or PNG format. Maximum file size 15 MB."
           id="setting_picture.help.profile"
           values={Object {}}
         />
@@ -203,7 +203,7 @@ exports[`components/SettingItemMin should match snapshot, on loading picture 1`]
         className="setting-list-item padding-top x2"
       >
         <FormattedMessage
-          defaultMessage="Upload a picture in BMP, JPG or PNG format."
+          defaultMessage="Upload a picture in BMP, JPG or PNG format. Maximum file size 15 MB."
           id="setting_picture.help.profile"
           values={Object {}}
         />
@@ -304,7 +304,7 @@ exports[`components/SettingItemMin should match snapshot, profile picture on fil
         className="setting-list-item padding-top x2"
       >
         <FormattedMessage
-          defaultMessage="Upload a picture in BMP, JPG or PNG format."
+          defaultMessage="Upload a picture in BMP, JPG or PNG format. Maximum file size 15 MB."
           id="setting_picture.help.profile"
           values={Object {}}
         />
@@ -396,7 +396,7 @@ exports[`components/SettingItemMin should match snapshot, profile picture on sou
         className="setting-list-item padding-top x2"
       >
         <FormattedMessage
-          defaultMessage="Upload a picture in BMP, JPG or PNG format."
+          defaultMessage="Upload a picture in BMP, JPG or PNG format. Maximum file size 15 MB."
           id="setting_picture.help.profile"
           values={Object {}}
         />


### PR DESCRIPTION
#### Summary
Appends the text "Maximum file size 15 MB." to the help text for uploading profile pictures.
![screenshot from 2018-07-09 16-22-12](https://user-images.githubusercontent.com/32583822/42481389-fedfb53a-8396-11e8-8e4d-3c3258be74ee.png)

#### Ticket Link
None

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
  - Tests:       10 skipped, 1190 passed, 1200 total
- [x] Has UI changes
- [x] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-webapp/blob/master/i18n/en.json)) updates
