### PR TITLE
[UCHAT-3452] Removed the option of giving user the display option to …

### DIFF
--- a/components/admin_console/admin_definition.jsx
+++ b/components/admin_console/admin_definition.jsx
@@ -573,11 +573,11 @@ export default {
                                     display_name: t('admin.team.showUsername'),
                                     display_name_default: 'Show username (default)',
                                 },
-                                {
-                                    value: Constants.TEAMMATE_NAME_DISPLAY.SHOW_NICKNAME_FULLNAME,
-                                    display_name: t('admin.team.showNickname'),
-                                    display_name_default: 'Show nickname if one exists, otherwise show first and last name',
-                                },
+                                // {
+                                //     value: Constants.TEAMMATE_NAME_DISPLAY.SHOW_NICKNAME_FULLNAME,
+                                //     display_name: t('admin.team.showNickname'),
+                                //     display_name_default: 'Show nickname if one exists, otherwise show first and last name',
+                                // },
                                 {
                                     value: Constants.TEAMMATE_NAME_DISPLAY.SHOW_FULLNAME,
                                     display_name: t('admin.team.showFullname'),

--- a/components/user_settings/display/user_settings_display.jsx
+++ b/components/user_settings/display/user_settings_display.jsx
@@ -503,14 +503,14 @@ export default class UserSettingsDisplay extends React.Component {
                     message: 'Show username',
                 },
             },
+            // thirdOption: {
+            //     value: Constants.TEAMMATE_NAME_DISPLAY.SHOW_NICKNAME_FULLNAME,
+            //     radionButtonText: {
+            //         id: t('user.settings.display.teammateNameDisplayNicknameFullname'),
+            //         message: 'HARRY | Show nickname if one exists, otherwise show first and last name',
+            //     },
+            // },
             secondOption: {
-                value: Constants.TEAMMATE_NAME_DISPLAY.SHOW_NICKNAME_FULLNAME,
-                radionButtonText: {
-                    id: t('user.settings.display.teammateNameDisplayNicknameFullname'),
-                    message: 'Show nickname if one exists, otherwise show first and last name',
-                },
-            },
-            thirdOption: {
                 value: Constants.TEAMMATE_NAME_DISPLAY.SHOW_FULLNAME,
                 radionButtonText: {
                     id: t('user.settings.display.teammateNameDisplayFullname'),


### PR DESCRIPTION
…see nickname of team members instead of username/full_name.

#### Summary
In User's Account Settings and Team&User Setting of the Admin Console, uChat currently gives users and admin the option to choose nickman as the attribute to be displayed for team members instead of username or fullname. However, uChat doesn't have the notion of nickname. Thus this change is to remove those options from all applicable places.

#### Ticket Link
https://jira.uberinternal.com/browse/UCHAT-3452

#### Related Pull Requests
Has server changes: No
Has redux changes: No
Has mobile changes: No

#### Testing
Done on localhost and verified that both user settings and admin console team display settings have got the option removed:

![User settings changes]
(https://drive.google.com/open?id=1Vvi9qYIX4JODjWcOIXCkmw75kcbIZ6HG)

![Admin console changes]
(https://drive.google.com/open?id=11ZdmOfi7giAmy3C_6PzUKFEPixMi9OoR)