### PR TITLE
[UCHAT-3952] Allow users to resize the sidebar.

### DIFF
--- a/components/sidebar/sidebar.jsx
+++ b/components/sidebar/sidebar.jsx
@@ -189,6 +189,25 @@ export default class Sidebar extends React.PureComponent {
         this.updateUnreadIndicators();
         document.addEventListener('keydown', this.navigateChannelShortcut);
         document.addEventListener('keydown', this.navigateUnreadChannelShortcut);
+        document.addEventListener('mouseup', this.unbind);
+        document.getElementById('sidebar-resizer').addEventListener('mousedown', this.resizePanel);
+    }
+
+    resizePanel(e) {
+        e.preventDefault();
+        $(document).mousemove((e) => {
+            e.preventDefault();
+            let xMargin = 0;
+            xMargin = e.pageX - $('#sidebar-left').offset().left;
+            if (xMargin > Constants.SIDEBAR_DEFAULT_WIDTH && e.pageX < 2 * Constants.SIDEBAR_DEFAULT_WIDTH) {
+                $('#sidebar-left').css('width', xMargin);
+                $('#app-content').css('margin-left', xMargin);
+            }
+        });
+    }
+
+    unbind() {
+        $(document).off('mousemove');
     }
 
     componentDidUpdate(prevProps) {
@@ -761,6 +780,10 @@ export default class Sidebar extends React.PureComponent {
                     {this.renderOrderedChannels()}
                 </div>
                 {quickSwitchText}
+                <div
+                    className='sidebar-resizer'
+                    id='sidebar-resizer'
+                />
             </div>
         );
     }

--- a/components/sidebar/sidebar_channel_button_or_link/sidebar_channel_button_or_link.jsx
+++ b/components/sidebar/sidebar_channel_button_or_link/sidebar_channel_button_or_link.jsx
@@ -10,6 +10,7 @@ import {mark, trackEvent} from 'actions/diagnostics_actions.jsx';
 import {isDesktopApp} from 'utils/user_agent.jsx';
 import CopyUrlContextMenu from 'components/copy_url_context_menu';
 
+import Constants from 'utils/constants.jsx';
 import SidebarChannelButtonOrLinkIcon from './sidebar_channel_button_or_link_icon.jsx';
 import SidebarChannelButtonOrLinkCloseButton from './sidebar_channel_button_or_link_close_button.jsx';
 
@@ -100,6 +101,17 @@ export default class SidebarChannelButtonOrLink extends React.PureComponent {
                     </button>
                 </CopyUrlContextMenu>
             );
+        } else if (this.props.displayName && this.props.displayName.length < Constants.SIDEBAR_DEFAULT_CHARACTERS) {
+            element = (
+                <Link
+                    id={`sidebarItem_${this.props.channelName}`}
+                    to={this.props.link}
+                    className={this.props.rowClass}
+                    onClick={this.trackChannelSelectedEvent}
+                >
+                    {content}
+                </Link>
+            );
         } else {
             element = (
                 <Link
@@ -107,6 +119,7 @@ export default class SidebarChannelButtonOrLink extends React.PureComponent {
                     to={this.props.link}
                     className={this.props.rowClass}
                     onClick={this.trackChannelSelectedEvent}
+                    title={this.props.displayName}
                 >
                     {content}
                 </Link>

--- a/sass/layout/_sidebar-left.scss
+++ b/sass/layout/_sidebar-left.scss
@@ -1,5 +1,15 @@
 @charset 'UTF-8';
 
+.sidebar-resizer {
+    height: 100%;
+    position: absolute;
+    right: -8px;
+    width: 8px;
+    z-index: 11;
+    cursor: col-resize;
+    display: block;        /* Likely future */
+}
+
 .sidebar--left {
     display: flex;
     flex-direction: column;

--- a/utils/constants.jsx
+++ b/utils/constants.jsx
@@ -698,6 +698,8 @@ export const Constants = {
     SYSTEM_MESSAGE_PREFIX: 'system_',
     AUTO_RESPONDER: 'system_auto_responder',
     SYSTEM_MESSAGE_PROFILE_IMAGE: logoImage,
+    SIDEBAR_DEFAULT_WIDTH: 220,
+    SIDEBAR_DEFAULT_CHARACTERS: 24,
     RESERVED_TEAM_NAMES: [
         'signup',
         'login',


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--

-->
This pull request has changes related to https://jira.uberinternal.com/browse/UCHAT-3952.
This will allow the user to resize the sidebar in case they want to resize.
Also, added the feature to show a tool tip when we hover on the channel name if it has more than 24 characters

#### Ticket Link
<!--


-->
JIRA ticket reference number:
https://jira.uberinternal.com/browse/UCHAT-3952

#### Related Pull Requests
<!--
List all PRs related to resolving a ticket. For instance, if you submitted a PR to `mattermost/mattermost-server`, please include it here.
-->
- Has server changes No
- Has redux changes No
- Has mobile changes No

Testing:
Tested the changes by running the webapp locally and able to resize the sidebar.
