### PR TITLE
UCHAT-3952-sidebar-resize- Code changes to resize the sidebar

### DIFF
--- a/components/sidebar/__snapshots__/sidebar.test.jsx.snap
+++ b/components/sidebar/__snapshots__/sidebar.test.jsx.snap
@@ -239,6 +239,11 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should match snapshot,
       </span>
     </button>
   </div>
+  <div
+    className="sidebar-resizer"
+    id="sidebar-resizer"
+    onMouseDown={[Function]}
+  />
 </div>
 `;
 
@@ -481,6 +486,11 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should match snapshot,
       </span>
     </button>
   </div>
+  <div
+    className="sidebar-resizer"
+    id="sidebar-resizer"
+    onMouseDown={[Function]}
+  />
 </div>
 `;
 
@@ -723,6 +733,11 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should match snapshot,
       </span>
     </button>
   </div>
+  <div
+    className="sidebar-resizer"
+    id="sidebar-resizer"
+    onMouseDown={[Function]}
+  />
 </div>
 `;
 
@@ -965,6 +980,11 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should match snapshot,
       </span>
     </button>
   </div>
+  <div
+    className="sidebar-resizer"
+    id="sidebar-resizer"
+    onMouseDown={[Function]}
+  />
 </div>
 `;
 
@@ -1215,6 +1235,11 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should show/hide corre
       </span>
     </button>
   </div>
+  <div
+    className="sidebar-resizer"
+    id="sidebar-resizer"
+    onMouseDown={[Function]}
+  />
 </div>
 `;
 
@@ -1457,6 +1482,11 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should show/hide corre
       </span>
     </button>
   </div>
+  <div
+    className="sidebar-resizer"
+    id="sidebar-resizer"
+    onMouseDown={[Function]}
+  />
 </div>
 `;
 
@@ -1703,6 +1733,11 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should show/hide corre
       </span>
     </button>
   </div>
+  <div
+    className="sidebar-resizer"
+    id="sidebar-resizer"
+    onMouseDown={[Function]}
+  />
 </div>
 `;
 
@@ -1945,6 +1980,11 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should show/hide corre
       </span>
     </button>
   </div>
+  <div
+    className="sidebar-resizer"
+    id="sidebar-resizer"
+    onMouseDown={[Function]}
+  />
 </div>
 `;
 
@@ -2187,6 +2227,11 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should show/hide corre
       </span>
     </button>
   </div>
+  <div
+    className="sidebar-resizer"
+    id="sidebar-resizer"
+    onMouseDown={[Function]}
+  />
 </div>
 `;
 
@@ -2429,5 +2474,10 @@ exports[`component/sidebar/sidebar_channel/SidebarChannel should show/hide corre
       </span>
     </button>
   </div>
+  <div
+    className="sidebar-resizer"
+    id="sidebar-resizer"
+    onMouseDown={[Function]}
+  />
 </div>
 `;

--- a/components/sidebar/sidebar.jsx
+++ b/components/sidebar/sidebar.jsx
@@ -189,6 +189,24 @@ export default class Sidebar extends React.PureComponent {
         this.updateUnreadIndicators();
         document.addEventListener('keydown', this.navigateChannelShortcut);
         document.addEventListener('keydown', this.navigateUnreadChannelShortcut);
+        document.addEventListener('mouseup', this.unbind);
+    }
+
+    resizePanel(event) {
+        event.preventDefault();
+        $(document).mousemove((e) => {
+            e.preventDefault();
+            let xMargin = 0;
+            xMargin = e.pageX - $('#sidebar-left').offset().left;
+            if (xMargin > Constants.SIDEBAR_DEFAULT_WIDTH && e.pageX < 2 * Constants.SIDEBAR_DEFAULT_WIDTH) {
+                $('#sidebar-left').css('width', xMargin);
+                $('#app-content').css('margin-left', e.pageX);
+            }
+        });
+    }
+
+    unbind() {
+        $(document).off('mousemove');
     }
 
     componentDidUpdate(prevProps) {
@@ -761,6 +779,11 @@ export default class Sidebar extends React.PureComponent {
                     {this.renderOrderedChannels()}
                 </div>
                 {quickSwitchText}
+                <div
+                    className='sidebar-resizer'
+                    id='sidebar-resizer'
+                    onMouseDown={this.resizePanel}
+                />
             </div>
         );
     }

--- a/components/sidebar/sidebar.test.jsx
+++ b/components/sidebar/sidebar.test.jsx
@@ -501,7 +501,7 @@ describe('component/sidebar/sidebar_channel/SidebarChannel', () => {
         );
         const instance = wrapper.instance();
 
-        expect(document.addEventListener).toHaveBeenCalledTimes(2);
+        expect(document.addEventListener).toHaveBeenCalledTimes(3);
         expect(document.removeEventListener).not.toBeCalled();
         instance.componentWillUnmount();
         expect(document.removeEventListener).toHaveBeenCalledTimes(2);

--- a/components/sidebar/sidebar_channel_button_or_link/sidebar_channel_button_or_link.jsx
+++ b/components/sidebar/sidebar_channel_button_or_link/sidebar_channel_button_or_link.jsx
@@ -5,10 +5,14 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {Link} from 'react-router-dom';
 
+import {OverlayTrigger, Tooltip} from 'react-bootstrap';
+
 import {browserHistory} from 'utils/browser_history';
 import {mark, trackEvent} from 'actions/diagnostics_actions.jsx';
 import {isDesktopApp} from 'utils/user_agent.jsx';
 import CopyUrlContextMenu from 'components/copy_url_context_menu';
+
+import Constants from 'utils/constants.jsx';
 
 import SidebarChannelButtonOrLinkIcon from './sidebar_channel_button_or_link_icon.jsx';
 import SidebarChannelButtonOrLinkCloseButton from './sidebar_channel_button_or_link_close_button.jsx';
@@ -100,7 +104,7 @@ export default class SidebarChannelButtonOrLink extends React.PureComponent {
                     </button>
                 </CopyUrlContextMenu>
             );
-        } else {
+        } else if (this.props.displayName && this.props.displayName.length < Constants.SIDEBAR_DEFAULT_CHARACTERS) {
             element = (
                 <Link
                     id={`sidebarItem_${this.props.channelName}`}
@@ -110,6 +114,23 @@ export default class SidebarChannelButtonOrLink extends React.PureComponent {
                 >
                     {content}
                 </Link>
+            );
+        } else {
+            element = (
+                <OverlayTrigger
+                    overlay={
+                        <Tooltip id={`sidebarItem_Tooltip_${this.props.channelName}`}>{this.props.displayName}</Tooltip>
+                    }
+                >
+                    <Link
+                        id={`sidebarItem_${this.props.channelName}`}
+                        to={this.props.link}
+                        className={this.props.rowClass}
+                        onClick={this.trackChannelSelectedEvent}
+                    >
+                        {content}
+                    </Link>
+                </OverlayTrigger>
             );
         }
 

--- a/components/team_sidebar/components/team_button.jsx
+++ b/components/team_sidebar/components/team_button.jsx
@@ -6,6 +6,8 @@ import React from 'react';
 import {OverlayTrigger, Tooltip} from 'react-bootstrap';
 import {Link} from 'react-router-dom';
 
+import $ from 'jquery';
+
 import {mark, trackEvent} from 'actions/diagnostics_actions.jsx';
 import Constants from 'utils/constants.jsx';
 import {isDesktopApp} from 'utils/user_agent.jsx';
@@ -25,6 +27,7 @@ export default class TeamButton extends React.Component {
         mark('TeamLink#click');
         trackEvent('ui', 'ui_team_sidebar_switch_team');
         this.props.switchTeam(this.props.url);
+        $('#sidebar-left').css('width', Constants.SIDEBAR_DEFAULT_WIDTH);
     }
 
     handleDisabled(e) {

--- a/sass/layout/_sidebar-left.scss
+++ b/sass/layout/_sidebar-left.scss
@@ -1,5 +1,15 @@
 @charset 'UTF-8';
 
+.sidebar-resizer {
+    height: 100%;
+    position: absolute;
+    right: -8px;
+    width: 8px;
+    z-index: 11;
+    cursor: col-resize;
+    display: block;        /* Likely future */
+}
+
 .sidebar--left {
     display: flex;
     flex-direction: column;

--- a/utils/constants.jsx
+++ b/utils/constants.jsx
@@ -698,6 +698,8 @@ export const Constants = {
     SYSTEM_MESSAGE_PREFIX: 'system_',
     AUTO_RESPONDER: 'system_auto_responder',
     SYSTEM_MESSAGE_PROFILE_IMAGE: logoImage,
+    SIDEBAR_DEFAULT_WIDTH: 220,
+    SIDEBAR_DEFAULT_CHARACTERS: 24,
     RESERVED_TEAM_NAMES: [
         'signup',
         'login',


### PR DESCRIPTION
…the sidebar

UCHAT-3952-sidebar-resize- code changes resize the sidebar. Also, to show the channel name as a tool tip for channels which has very long names.

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
This PR has code changes to resize the sidebar channel, so that user can see the full channel name after resizing the sidebar.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

https://jira.uberinternal.com/browse/IT-1046524

#### Related Pull Requests
<!--
List all PRs related to resolving a ticket. For instance, if you submitted a PR to `mattermost/mattermost-server`, please include it here.
-->
- Has server changes No
- Has redux changes No
- Has mobile changes No
