### PR TITLE
UCHAT-3952-sidebar-resize- bug fix for UI gets distorted

### DIFF
--- a/components/channel_layout/center_channel/center_channel.jsx
+++ b/components/channel_layout/center_channel/center_channel.jsx
@@ -6,6 +6,8 @@ import PropTypes from 'prop-types';
 import {Route, Switch, Redirect} from 'react-router-dom';
 import classNames from 'classnames';
 
+import $ from 'jquery';
+
 import PermalinkView from 'components/permalink_view';
 import ChannelHeaderMobile from 'components/channel_header_mobile';
 import ChannelIdentifierRouter from 'components/channel_layout/channel_identifier_router';
@@ -31,6 +33,11 @@ export default class CenterChannel extends React.PureComponent {
         if (this.props.location.pathname !== nextProps.location.pathname && nextProps.location.pathname.includes('/pl/')) {
             this.setState({returnTo: this.props.location.pathname});
         }
+        this.leftMargin = $('#app-content').css('margin-left');
+    }
+
+    componentDidUpdate() {
+        $('#app-content').css('margin-left', this.leftMargin);
     }
 
     render() {

--- a/components/channel_view/channel_view.jsx
+++ b/components/channel_view/channel_view.jsx
@@ -63,6 +63,7 @@ export default class ChannelView extends React.PureComponent {
         if (this.props.match.url !== nextProps.match.url) {
             this.createDeferredPostView();
         }
+        this.leftMargin = $('#app-content').css('margin-left');
     }
 
     getChannelView = () => {
@@ -96,6 +97,7 @@ export default class ChannelView extends React.PureComponent {
                 this.props.actions.goToLastViewedChannel();
             }
         }
+        $('#app-content').css('margin-left', this.leftMargin);
     }
 
     render() {

--- a/components/permalink_view/permalink_view.jsx
+++ b/components/permalink_view/permalink_view.jsx
@@ -6,6 +6,8 @@ import PropTypes from 'prop-types';
 import {FormattedMessage, intlShape} from 'react-intl';
 import {Link} from 'react-router-dom';
 
+import $ from 'jquery';
+
 import ChannelHeader from 'components/channel_header';
 import PostView from 'components/post_view';
 import FormattedMarkdownMessage from 'components/formatted_markdown_message';
@@ -53,6 +55,11 @@ export default class PermalinkView extends React.PureComponent {
         if (this.props.match.params.postid !== nextProps.match.params.postid) {
             this.doPermalinkEvent(nextProps);
         }
+        this.leftMargin = $('#app-content').css('margin-left');
+    }
+
+    componentDidUpdate() {
+        $('#app-content').css('margin-left', this.leftMargin);
     }
 
     doPermalinkEvent = async (props) => {


### PR DESCRIPTION
…gating through pinned posts.

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
After we resize the sidebar and then open the pinned posts, UI gets distorted.
This PR has the fix for this issue.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://jira.uberinternal.com/browse/UCHAT-4573

#### Related Pull Requests
<!--
List all PRs related to resolving a ticket. For instance, if you submitted a PR to `mattermost/mattermost-server`, please include it here.
-->
- Has server changes No
- Has redux changes No
- Has mobile changes No
