### PR TITLE
UCHAT-4639 URL overlapping "[someone] is typing" text.

### DIFF
--- a/components/textbox/textbox.jsx
+++ b/components/textbox/textbox.jsx
@@ -333,6 +333,17 @@ export default class Textbox extends React.Component {
                     {helpText}
                     {previewLink}
                     <Link
+                        id='feedbackTextLink'
+                        rel='noopener noreferrer'
+                        to='/uber/channels/feedback'
+                        className='textbox-help-link'
+                    >
+                        <FormattedMessage
+                            id='textbox.feedback'
+                            defaultMessage='Feedback'
+                        />
+                    </Link>
+                    <Link
                         id='helpTextLink'
                         target='_blank'
                         rel='noopener noreferrer'

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -2940,6 +2940,7 @@
   "textbox.bold": "**bold**",
   "textbox.edit": "Edit message",
   "textbox.help": "Help",
+  "textbox.feedback": "Feedback",
   "textbox.inlinecode": "`inline code`",
   "textbox.italic": "_italic_",
   "textbox.preformatted": "```preformatted```",

--- a/sass/layout/_post.scss
+++ b/sass/layout/_post.scss
@@ -714,7 +714,7 @@
         display: block;
         font-size: .95em;
         height: 20px;
-        margin-bottom: 5px;
+        margin-bottom: 20px;
         overflow: hidden;
         text-overflow: ellipsis;
         white-space: nowrap;


### PR DESCRIPTION
…margin bottom to avoid the overlapping

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Link preview at the bottom gets overlapped with someone is typing area. Due to this, sometimes users are unable to know if someone is typing or not. This fix is to remove the overlap.
<!--
A description of what this pull request does.
-->

#### Ticket Link
https://jira.uberinternal.com/browse/UCHAT-4639
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Related Pull Requests
<!--
List all PRs related to resolving a ticket. For instance, if you submitted a PR to `mattermost/mattermost-server`, please include it here.
-->
- Has server changes No
- Has redux changes No
- Has mobile changes No