### PR TITLE
UCHAT-4634 Mobile View in Web App misaligns after resizing the sidebar. 

### DIFF
--- a/sass/responsive/_mobile.scss
+++ b/sass/responsive/_mobile.scss
@@ -1498,11 +1498,12 @@
     .multi-teams {
 
         .app__content {
-            margin-left: 0;
+            margin-left: 0 !important;
         }
 
         .sidebar--left {
-            left: 0;
+            left: 0 !important;
+            width: 220px !important;
 
             &.move--right {
                 left: 65px;

--- a/sass/responsive/_mobile_uchat.scss
+++ b/sass/responsive/_mobile_uchat.scss
@@ -1605,14 +1605,15 @@
     .multi-teams {
 
         .app__content {
-            margin-left: 0;
+            margin-left: 0 !important;
         }
 
         .sidebar--left {
-            left: 0;
+            left: 0 !important;
+            width: 220px !important;
 
             &.move--right {
-                left: 65px;
+                left: 65px !important;
             }
 
             .nav-pills__unread-indicator {


### PR DESCRIPTION

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
After user resizes the sidebar and then minimize the window, Mobile view gets loaded. In this scenario, it gets distorted due to resizing. If the user does not resize the sidebar and then minimize the window, then Mobile View gets loaded fine.

This PR is to fix that issue. 
<!--
A description of what this pull request does.
-->

#### Ticket Link
https://jira.uberinternal.com/browse/UCHAT-4634
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Related Pull Requests
<!--
List all PRs related to resolving a ticket. For instance, if you submitted a PR to `mattermost/mattermost-server`, please include it here.
-->
- Has server changes No
- Has redux changes No
- Has mobile changes No
